### PR TITLE
27 implementation of cache in music ressources

### DIFF
--- a/backend/src/main/java/ch/heigvd/music/MusicController.java
+++ b/backend/src/main/java/ch/heigvd/music/MusicController.java
@@ -25,10 +25,13 @@ public class MusicController {
      */
   public void getAll(Context ctx) {
 
-      List<Music> musics = musicService.getAllMusics();
+    List<Music> musics = musicService.getAllMusics();
 
-      ctx.json(musics);
-    }
+    // Cache the response for ALL_MUSICS_CACHE_MAX_AGE_SECONDS seconds
+    ctx.header("Cache-Control", "max-age=" + ALL_MUSICS_CACHE_MAX_AGE_SECONDS);
+
+    ctx.json(musics);
+  }
 
   /**
    * Handles the HTTP GET request to retrieve a music by its ID.
@@ -41,8 +44,6 @@ public class MusicController {
     Music music = musicService.getMusic(musicId);
 
     // Cache the response for MUSIC_ID_CACHE_MAX_AGE_SECONDS seconds
-    // Everything's been tested as it should be, but we weren't able to see the effect of caching
-    // We even verified with our teacher
     ctx.header("Cache-Control", "max-age=" + MUSIC_ID_CACHE_MAX_AGE_SECONDS);
 
     ctx.json(music);
@@ -62,8 +63,6 @@ public class MusicController {
     List<Music> musics = musicService.getTenLastListenedMusics(username);
 
     // Cache the response for TEN_LAST_LISTENED_CACHE_MAX_AGE_SECONDS seconds
-    // Everything's been tested as it should be, but we weren't able to see the effect of caching
-    // We even verified with our teacher
     ctx.header("Cache-Control", "max-age=" + TEN_LAST_LISTENED_CACHE_MAX_AGE_SECONDS);
 
     ctx.json(musics);
@@ -83,8 +82,6 @@ public class MusicController {
     List<Music> musics = musicService.getTenMostListenedMusics(username);
 
     // Cache the response for TEN_MOST_LISTENED_CACHE_MAX_AGE_SECONDS seconds
-    // Everything's been tested as it should be, but we weren't able to see the effect of caching
-    // We even verified with our teacher
     ctx.header("Cache-Control", "max-age=" + TEN_MOST_LISTENED_CACHE_MAX_AGE_SECONDS);
 
     ctx.json(musics);
@@ -104,8 +101,6 @@ public class MusicController {
     List<Music> musics = musicService.getLikedMusics(username);
 
     // Cache the response for LIKED_MUSICS_CACHE_MAX_AGE_SECONDS seconds
-    // Everything's been tested as it should be, but we weren't able to see the effect of caching
-    // We even verified with our teacher
     ctx.header("Cache-Control", "max-age=" + LIKED_MUSICS_CACHE_MAX_AGE_SECONDS);
 
     ctx.json(musics);


### PR DESCRIPTION
# How to test

After launching the database and the application, you need to open the link given in the console and add the route wanted to test. For example : 

`http://localhost:8080/musics`

You can then open the developper tool and go to `Network` and make sure that `Disable cache` is NOT checked and then refresh the page to see the incoming response. You should see the `Cache-Control` tab with the value of the expiration the data is cached for. You can check `Preserve log` to keep all the responses made on the page.

If you don't see the `Cache-Control` tab you can activate it by following these instructions:

1. Right click on the table
2. Click on `Header Options`
3. Click on `Response Headers`
4. Check the option `Cache-Control`

You should now have the `Cache-Control` tab.

Only refreshing via F5 won't tell you directly if the cache is working. You need to open a new page, open the developper tool and THEN go to the same URL and you will see in the `size` tab that the response was cached and the `Status` tab has the status code greyed out.

This particularity of F5 not using the cache is something coming from the browser that will think that, IF we refresh via F5, it means that we want the last modification of the page and not a version coming from the cache that might be outdated.